### PR TITLE
Changing the maven configurations and commenting out the invokation part from the main method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,8 +71,8 @@
     </build>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>22</maven.compiler.source>
+        <maven.compiler.target>22</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/src/main/java/am/aua/library/Application.java
+++ b/src/main/java/am/aua/library/Application.java
@@ -20,6 +20,6 @@ public class Application {
         // the information.
         Database.setDirectory(baseDirectory);
         // Starting the UI using SwingUtilities
-        SwingUtilities.invokeLater(MainView::new);
+        //SwingUtilities.invokeLater(MainView::new);
     }
 }


### PR DESCRIPTION
In the maven configurations, I set the maven compiler source and maven compiler target values to 22 from 17, to match the JDK versions. Also, I temporarily commented out the ```SwingUtilities.invokeLater(MainView::new);``` line, which needs to be replaced with another statement, since the invokation of the constructor of MainView class causes an error. 